### PR TITLE
Universal startup script

### DIFF
--- a/scripts/universal-startup/config.bash
+++ b/scripts/universal-startup/config.bash
@@ -1,0 +1,13 @@
+# Modify this address to match your server.
+serverAddress="10.72.21.42"
+
+# Add all client SSH addresses to this array. To  avoid being
+# asked for a password each time, setup SSH keys.
+#
+# Example:
+# clientAddresses=(\
+# "odroid@10.72.20.59" \
+# "odroid@10.72.21.38" \
+#)
+
+clientAddresses=()

--- a/scripts/universal-startup/get_result.bash
+++ b/scripts/universal-startup/get_result.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Fetch the logs and results from all devices stored in "config.bash"
+
+timestamp=`date +%s`
+
+echo "Fetching results into \$VECTORADD_DIR/log/$timestamp"
+
+mkdir -p $VECTORADD_DIR/log
+mkdir -p $VECTORADD_DIR/log/$timestamp
+
+source $VECTORADD_DIR/bin/universal-startup/config.bash
+
+for ip in "${clientAddresses[@]}"
+do
+  echo fetching from $ip...
+  ssh $ip "cd \$VECTORADD_DIR; tar -zcvf vectoradd.log.tar.gz vectoradd.log" 2>&1 > /dev/null
+  
+  scp $ip:\$VECTORADD_DIR/result.tar.gz log/$timestamp/result.tar.gz 2> /dev/null
+  scp $ip:\$VECTORADD_DIR/vectoradd.log.tar.gz log/$timestamp/log.$ip.tar.gz
+done

--- a/scripts/universal-startup/run_distributed.bash
+++ b/scripts/universal-startup/run_distributed.bash
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Executes vectoradd with Constellation on all devices listed in config.bash
+# The device which calls this script, will act as the server.
+
+# --- REQUIREMENTS ---
+# * All devices must have $VECTORADD_DIR and $CONSTELLATION_PORT set as environment
+# variables upon SSH access, this can be done in the ~/.ssh/environment file.
+# * The devices acting as clients do not need to have the full repository locally, 
+# only the jar files (lib/*) and the scripts. However, they must be using the 
+# file _same_ relative file structure, as the repo.
+
+# Result and logs can be retrieved from all devices by running the script bin/universal-startup/get_results.bash
+
+if [ "$#" -ne 4 ]; then
+        echo "Wrong number of arguments --Remember to execute on device running server--"
+        echo "Usage: $0 -n <vector_length> -computeDivideThreshold <threshold>"
+        exit
+fi
+
+# Change the path to fit your system
+tmpdir=$VECTORADD_DIR/java-io-tmpdir
+
+mkdir -p $tmpdir
+rm -rf $tmpdir/*.so
+
+timestamp=`date +%s`
+
+# Get adresses of all devices
+source $VECTORADD_DIR/bin/universal-startup/config.bash
+
+nrNodes=${#clientAddresses[*]}
+
+if [ $nrNodes -eq 0 ]; then
+  echo "Add at least one client in config.bash"
+  exit
+fi
+
+className="nl.junglecomputing.constellation.vectoradd.VectorAdd"
+poolName="constellation.pool.$timestamp"
+jar="lib/vector-add-constellation.jar"
+args="-n $2 -computeDivideThreshold $4"
+
+# Client timeout duration in seconds (use -1 for keep open)
+clientTimeout=15
+
+# Start Server
+x-terminal-emulator -e "$VECTORADD_DIR/bin/constellation-server"
+
+for ip in "${clientAddresses[@]}"
+do
+  x-terminal-emulator -e ssh $ip "\$VECTORADD_DIR/bin/universal-startup/start_client.bash $clientTimeout $serverAddress $nrNodes $className $poolName $args 2>&1 | tee \$VECTORADD_DIR/vectoradd.log"
+done
+

--- a/scripts/universal-startup/start_client.bash
+++ b/scripts/universal-startup/start_client.bash
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Change the path to fit your system
+tmpdir=$VECTORADD_DIR/java-io-tmpdir
+
+mkdir -p $tmpdir
+rm -rf $tmpdir/*.so
+
+clientTimeout=$1; shift
+serverAddress=$1; shift
+nrNodes=$1; shift
+className=$1; shift
+poolName=$1; shift
+args="$@"
+
+if [ -z "$args" ]; then
+  echo "Missing one or more arguments"
+  sleep 5
+  exit
+fi
+
+jar="lib/vector-add-constellation.jar"
+
+className="nl.junglecomputing.constellation.vectoradd.VectorAdd"
+
+echo "Hello from $HOSTNAME"
+echo "starting client with arguments: $args"
+echo "connecting to server at: $serverAddress using port $CONSTELLATION_PORT"
+
+sleep 2
+
+# *******NOTE*******
+# The variables $VECTORADD_DIR and $CONSTELLATION_PORT MUST be added to the environment
+# in the shell accessed by ssh. For example by adding them to the ~/.ssh/environment file
+
+# Start Clients
+java -cp $VECTORADD_DIR/lib/*:$CLASSPATH \
+        -Djava.rmi.server.hostname=localhost \
+        -Djava.io.tmpdir=$tmpdir \
+        -Dlog4j.configuration=file:$VECTORADD_DIR/log4j.properties \
+        -Dibis.server.address=$serverAddress:$CONSTELLATION_PORT \
+        -Dibis.pool.size=$nrNodes \
+        -Dibis.server.port=$CONSTELLATION_PORT \
+        -Dibis.pool.name=$poolName \
+        -Dibis.constellation.closed=true \
+        $className \
+        $args
+
+# Only master has result
+result=~/vectoradd.out
+if [ -f "$result" ]; then
+  # Compress results to prepare for copying to host, keep original
+  cd ~/
+  tar -zcvf $VECTORADD_DIR/result.tar.gz vectoradd.out
+  mv vectoradd.out $VECTORADD_DIR/vectoradd.out
+fi
+
+if [ $clientTimeout -lt 0 ]; then
+  while :; do
+    sleep 10
+  done
+else
+  echo "Shutting down connection in $clientTimeout seconds"
+  sleep $clientTimeout
+fi
+
+

--- a/scripts/universal-startup/start_client.bash
+++ b/scripts/universal-startup/start_client.bash
@@ -53,6 +53,9 @@ if [ -f "$result" ]; then
   cd ~/
   tar -zcvf $VECTORADD_DIR/result.tar.gz vectoradd.out
   mv vectoradd.out $VECTORADD_DIR/vectoradd.out
+else
+  # Remove possible leftover results from previous runs
+  rm -rf $VECTORADD_DIR/result.tar.gz
 fi
 
 if [ $clientTimeout -lt 0 ]; then


### PR DESCRIPTION
The script universal-startup/run_distributed.bash starts a server and uses SSH to run the clients remotely, specify addresses in the universal-startup/config.bash file. To fetch the result of the computation and the logs from the nodes, run he script universal-startup/get_result.bash

The scripts have been tested on 7 Odroids, running Ubuntu. 